### PR TITLE
implemented seasonal calendar page

### DIFF
--- a/lib/src/core/utils/navigation_drawer/custom_navigation_drawer.dart
+++ b/lib/src/core/utils/navigation_drawer/custom_navigation_drawer.dart
@@ -218,6 +218,7 @@ class CustomNavigationDrawerDestination extends StatelessWidget {
     required this.icon,
     this.selectedIcon,
     required this.label,
+    this.onTap,
   });
 
   /// Sets the color of the [Material] that holds all of the [Drawer]'s
@@ -253,6 +254,9 @@ class CustomNavigationDrawerDestination extends StatelessWidget {
   /// [NavigationDrawerThemeData.labelTextStyle]. If this are null, the default
   /// text style would use [TextTheme.labelLarge] with [ColorScheme.onSurfaceVariant].
   final Widget label;
+
+  /// Callback function when the destination is tapped
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -293,11 +297,14 @@ class CustomNavigationDrawerDestination extends StatelessWidget {
         final TextStyle? effectiveUnselectedLabelTextStyle =
             navigationDrawerTheme.labelTextStyle?.resolve(unselectedState) ??
                 defaults.labelTextStyle!.resolve(unselectedState);
-        return DefaultTextStyle(
-          style: _isForwardOrCompleted(animation)
-              ? effectiveSelectedLabelTextStyle!
-              : effectiveUnselectedLabelTextStyle!,
-          child: label,
+        return GestureDetector(
+          onTap: onTap,
+          child: DefaultTextStyle(
+            style: _isForwardOrCompleted(animation)
+                ? effectiveSelectedLabelTextStyle!
+                : effectiveUnselectedLabelTextStyle!,
+            child: label,
+          ),
         );
       },
     );

--- a/lib/src/core/utils/navigation_drawer/my_navigation_drawer.dart
+++ b/lib/src/core/utils/navigation_drawer/my_navigation_drawer.dart
@@ -1,4 +1,6 @@
 import 'package:animu_cal/src/core/providers/navigation_drawer_provider.dart';
+import 'package:animu_cal/src/views/seasonal_calendar/seasonal_calendar.dart';
+import 'package:animu_cal/src/views/top_rated.dart/top_rated.dart';
 import 'package:animu_cal/theme.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -56,6 +58,16 @@ class MyNavigationDrawer extends ConsumerWidget {
           ),
           CustomNavigationDrawerDestination(
               icon: Icon(
+                CupertinoIcons.star_fill,
+                color: MyColors.saffron,
+              ),
+              label: const Text('Top Rated'),
+              onTap: () {
+                Navigator.of(context).push(
+                    MaterialPageRoute(builder: (context) => const TopRated()));
+              }),
+          CustomNavigationDrawerDestination(
+              icon: Icon(
                 CupertinoIcons.calendar,
                 color: MyColors.sandyBrown,
               ),
@@ -63,25 +75,25 @@ class MyNavigationDrawer extends ConsumerWidget {
                 'Seasonal Calendar',
                 textHeightBehavior:
                     TextHeightBehavior(applyHeightToLastDescent: false),
-              )),
-          const CustomNavigationDrawerDestination(
-              icon: Icon(
+              ),
+              onTap: () {
+                Navigator.of(context).push(MaterialPageRoute(
+                    builder: (context) => const SeasonalCalendar()));
+              }),
+          CustomNavigationDrawerDestination(
+              icon: const Icon(
                 CupertinoIcons.heart_fill,
                 color: Colors.redAccent,
               ),
-              label: Text('Favourites')),
-          CustomNavigationDrawerDestination(
-              icon: Icon(
-                CupertinoIcons.star_fill,
-                color: MyColors.saffron,
-              ),
-              label: const Text('Top Rated')),
+              label: const Text('Favourites'),
+              onTap: () {}),
           CustomNavigationDrawerDestination(
               icon: Icon(
                 CupertinoIcons.calendar_today,
                 color: MyColors.persianGreen,
               ),
-              label: const Text('Airing Today')),
+              label: const Text('Airing Today'),
+              onTap: () {}),
           Divider(
             height: 50,
             color: MyColors.persianGreen,
@@ -89,18 +101,20 @@ class MyNavigationDrawer extends ConsumerWidget {
             indent: 12,
             endIndent: 12,
           ),
-          const CustomNavigationDrawerDestination(
-              icon: Icon(
+          CustomNavigationDrawerDestination(
+              icon: const Icon(
                 CupertinoIcons.settings_solid,
                 color: Colors.grey,
               ),
-              label: Text('Settings')),
-          const CustomNavigationDrawerDestination(
-              icon: Icon(
+              label: const Text('Settings'),
+              onTap: () {}),
+          CustomNavigationDrawerDestination(
+              icon: const Icon(
                 CupertinoIcons.person_3_fill,
                 color: Colors.grey,
               ),
-              label: Text('About')),
+              label: const Text('About'),
+              onTap: () {}),
         ]);
   }
 }

--- a/lib/src/views/get_started/get_started.dart
+++ b/lib/src/views/get_started/get_started.dart
@@ -1,3 +1,4 @@
+import 'package:animu_cal/src/views/top_rated.dart/top_rated.dart';
 import 'package:animu_cal/theme.dart';
 import 'package:flutter/material.dart';
 
@@ -24,7 +25,10 @@ class GetStarted extends StatelessWidget {
                   borderRadius: BorderRadius.circular(8),
                 ),
               ),
-              onPressed: () {},
+              onPressed: () {
+                Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(builder: (context) => TopRated()));
+              },
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [

--- a/lib/src/views/seasonal_calendar/controller/seasonal_calendar_controller.dart
+++ b/lib/src/views/seasonal_calendar/controller/seasonal_calendar_controller.dart
@@ -1,0 +1,63 @@
+import 'package:jikan_api/jikan_api.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/utils/my_jikan.dart';
+part 'seasonal_calendar_controller.g.dart';
+
+@riverpod
+class ShowOptions extends _$ShowOptions {
+  @override
+  bool build() {
+    return false;
+  }
+
+  void toggle() {
+    state = !state;
+  }
+}
+
+@riverpod
+Future<void> mySeasonalAnimeFuture(MySeasonalAnimeFutureRef ref) async {
+  return ref.watch(mySeasonalAnimeProvider.notifier).setSeasonalAnime();
+}
+
+@riverpod
+class MySeasonalAnime extends _$MySeasonalAnime {
+  SeasonType? _season;
+  int? _year;
+
+  @override
+  List<Anime> build() {
+    return [];
+  }
+
+  SeasonType? getSeason() {
+    return _season;
+  }
+
+  setSeason(SeasonType? season) {
+    _season = season;
+  }
+
+  int? getYear() {
+    return _year;
+  }
+
+  setYear(int? year) {
+    _year = year;
+  }
+
+  Future<List<Anime>> getSeasonalAnime() async {
+    final jikan = MyJikan.getInstance();
+    final season = _season;
+    final year = _year;
+    List<Anime> list = await jikan
+        .getSeason(season: season, year: year)
+        .then((value) => value.toList());
+    return list;
+  }
+
+  Future<void> setSeasonalAnime() async {
+    state = await getSeasonalAnime();
+  }
+}

--- a/lib/src/views/seasonal_calendar/controller/seasonal_calendar_controller.g.dart
+++ b/lib/src/views/seasonal_calendar/controller/seasonal_calendar_controller.g.dart
@@ -1,0 +1,57 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'seasonal_calendar_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$mySeasonalAnimeFutureHash() =>
+    r'c25ae0907f4cab202c6bb17fe2266edbaffceaa7';
+
+/// See also [mySeasonalAnimeFuture].
+@ProviderFor(mySeasonalAnimeFuture)
+final mySeasonalAnimeFutureProvider = AutoDisposeFutureProvider<void>.internal(
+  mySeasonalAnimeFuture,
+  name: r'mySeasonalAnimeFutureProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$mySeasonalAnimeFutureHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef MySeasonalAnimeFutureRef = AutoDisposeFutureProviderRef<void>;
+String _$showOptionsHash() => r'9d0ff35212945fd4d5cbffa4b76860e6d4ec7f94';
+
+/// See also [ShowOptions].
+@ProviderFor(ShowOptions)
+final showOptionsProvider =
+    AutoDisposeNotifierProvider<ShowOptions, bool>.internal(
+  ShowOptions.new,
+  name: r'showOptionsProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$showOptionsHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$ShowOptions = AutoDisposeNotifier<bool>;
+String _$mySeasonalAnimeHash() => r'ed8bef3809b258557dab411436b7e68158c482da';
+
+/// See also [MySeasonalAnime].
+@ProviderFor(MySeasonalAnime)
+final mySeasonalAnimeProvider =
+    AutoDisposeNotifierProvider<MySeasonalAnime, List<Anime>>.internal(
+  MySeasonalAnime.new,
+  name: r'mySeasonalAnimeProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$mySeasonalAnimeHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$MySeasonalAnime = AutoDisposeNotifier<List<Anime>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/src/views/seasonal_calendar/seasonal_calendar.dart
+++ b/lib/src/views/seasonal_calendar/seasonal_calendar.dart
@@ -1,0 +1,133 @@
+import 'package:animu_cal/src/core/utils/app_bar.dart';
+import 'package:animu_cal/src/core/utils/card/widgets/card_grid.dart';
+import 'package:animu_cal/src/core/utils/navigation_drawer/my_navigation_drawer.dart';
+import 'package:animu_cal/src/views/seasonal_calendar/controller/seasonal_calendar_controller.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:jikan_api/jikan_api.dart';
+import 'package:animu_cal/theme.dart';
+
+class SeasonalCalendar extends ConsumerWidget {
+  const SeasonalCalendar({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    var animeListFuture = ref.watch(mySeasonalAnimeFutureProvider);
+    List<Anime> animeList = ref.watch(mySeasonalAnimeProvider);
+
+    List<int> years = List.generate(
+        DateTime.now().year - 1899, (index) => DateTime.now().year - index);
+
+    return Scaffold(
+      drawer: const MyNavigationDrawer(),
+      body: CustomScrollView(
+        physics: const BouncingScrollPhysics(),
+        slivers: [
+          const MyAppBar(),
+          CupertinoSliverRefreshControl(
+            refreshTriggerPullDistance: 150,
+            onRefresh: () async {},
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+              child: Column(children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Seasonal Anime',
+                      style: Theme.of(context).textTheme.displayMedium,
+                    ),
+                    ElevatedButton(
+                        onPressed: () {
+                          ref.read(showOptionsProvider.notifier).toggle();
+                        },
+                        child: const Text('Season'))
+                  ],
+                ),
+                ref.watch(showOptionsProvider)
+                    ? Container(
+                        width: double.infinity,
+                        decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(10)),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8.0),
+                          child: Column(children: [
+                            DropdownMenu(
+                              label: const Text("Season"),
+                              width: MediaQuery.sizeOf(context).width - 32,
+                              onSelected: (value) {
+                                ref
+                                    .read(mySeasonalAnimeProvider.notifier)
+                                    .setSeason(value);
+                              },
+                              dropdownMenuEntries: [
+                                ...SeasonType.values.map((e) {
+                                  String item =
+                                      e.toString().toUpperCase().split('.')[1];
+                                  return DropdownMenuEntry(
+                                      value: e, label: item);
+                                }),
+                                const DropdownMenuEntry(
+                                    value: null, label: 'None')
+                              ],
+                            ),
+                            const SizedBox(
+                              height: 16,
+                            ),
+                            DropdownMenu(
+                              label: const Text('Year'),
+                              width: MediaQuery.sizeOf(context).width - 32,
+                              onSelected: (value) {
+                                ref
+                                    .read(mySeasonalAnimeProvider.notifier)
+                                    .setYear(value as int?);
+                              },
+                              dropdownMenuEntries:
+                                  List<DropdownMenuEntry<Object>>.generate(
+                                years.length,
+                                (index) => DropdownMenuEntry(
+                                  value: years[index],
+                                  label: '${years[index]}',
+                                ),
+                              ),
+                            ),
+                            const SizedBox(
+                              height: 16,
+                            ),
+                            SizedBox(
+                                width: double.infinity,
+                                child: FilledButton(
+                                    onPressed: () {
+                                      ref
+                                          .read(
+                                              mySeasonalAnimeProvider.notifier)
+                                          .setSeasonalAnime();
+                                    },
+                                    child: Text(
+                                      'Search',
+                                      style: TextStyle(color: MyColors.black),
+                                    ))),
+                          ]),
+                        ),
+                      )
+                    : const SizedBox()
+              ]),
+            ),
+          ),
+          animeListFuture.when(data: (data) {
+            return CardGrid(animeList: animeList);
+          }, error: (error, stackTrace) {
+            print("Error in SEASONAL SECTION: $error");
+            return const SliverToBoxAdapter();
+          }, loading: () {
+            print("LOADING");
+            return const SliverToBoxAdapter();
+          })
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# Pull Request 🚀

## Description
<!-- Briefly describe the purpose and changes introduced by this pull request. -->
Implemented seasonal calendar page and routing from the custom navigation drawer to the seasonal calendar screen

## Related Issues 🐛
<!-- Mention any related issues that this PR addresses or closes. Use keywords like "Closes #123" or "Fixes #456". -->
Fixes #12 

## Changes Made 🛠️
<!-- Provide a high-level overview of the changes made in this PR. -->
The seasonal calendar screen takes 2 inputs (season and year) and calls the function setSeasonalAnime() which returns the list of anime in that particular year and season. Added the onTap functionality on the navigation drawer for routing between screens.

## Screenshots 📸
<!-- If applicable, include screenshots or animated GIFs to visually demonstrate the changes. -->
![WhatsApp Image 2024-01-15 at 18 54 58_ee47eae2](https://github.com/Abhigyan103/AniAirs/assets/96365625/4eb5720e-3a51-4f65-b710-4ad4933e5fdd)


## Checklist ✅
<!-- Mark the items below when they are applicable or completed. -->
- [ ✔] Code follows the project's coding standards.
- [ ✔] The code runs on my device.
- [ ✔] I have not broken anything in the process.
- [ ✔] The branch is up-to-date with the base branch (usually `main`).
- [ ] Tests have been added for new functionality or bug fixes.

## Additional Notes 📝
<!-- Any additional information that might be helpful for reviewers or users testing the changes. -->
The controller of the custom navigation drawer has been modified by adding onTap function and wrapping the returning function with Gesture detector so that onTap functions correctly.
